### PR TITLE
Speedup

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -231,8 +231,9 @@ class Article(object):
         title = self.extractor.get_title(self.clean_doc)
         self.set_title(title)
 
-        authors = self.extractor.get_authors(self.clean_doc)
-        self.set_authors(authors)
+        if self.config.fetch_authors:
+            authors = self.extractor.get_authors(self.clean_doc)
+            self.set_authors(authors)
 
         meta_lang = self.extractor.get_meta_lang(self.clean_doc)
         self.set_meta_language(meta_lang)

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -42,6 +42,9 @@ class Configuration(object):
         # Cache and save articles run after run
         self.memoize_articles = True
 
+        # Set this to false if you don't care about getting authors
+        self.fetch_authors = True
+
         # Set this to false if you don't care about getting images
         self.fetch_images = True
         self.image_dimension_ration = 16 / 9.0

--- a/newspaper/parsers.py
+++ b/newspaper/parsers.py
@@ -186,6 +186,10 @@ class Parser(object):
         return node.xpath('//comment()')
 
     @classmethod
+    def isComment(cls, node):
+        return isinstance(node, lxml.html.HtmlComment)
+
+    @classmethod
     def getParent(cls, node):
         return node.getparent()
 
@@ -214,6 +218,10 @@ class Parser(object):
     def getText(cls, node):
         txts = [i for i in node.itertext()]
         return text.innerTrim(' '.join(txts).strip())
+
+    @classmethod
+    def hasText(cls, node):
+        return any(i and not i.isspace() for i in node.itertext())
 
     @classmethod
     def previousSiblings(cls, node):


### PR DESCRIPTION
For one set of documents it took about 8.2 seconds to process them, now it takes 4.2 seconds.
Changes:
- Change finding node by attributes (or tags or xpath) to looking through all nodes and checking condition for them in cleaning of article and in extraction of publishing date
- Added option not to extract authors